### PR TITLE
Add FastAPI backend and multiple frontend scaffolds

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "11001"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+
+app = FastAPI()
+
+@app.get("/", response_class=HTMLResponse)
+async def read_root():
+    return """
+    <!doctype html>
+    <html lang=\"en\">
+    <head>
+      <meta charset=\"utf-8\">
+      <title>Backend API</title>
+      <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
+    </head>
+    <body class=\"container py-5\">
+      <h1>Backend API</h1>
+      <p>This is the API service.</p>
+    </body>
+    </html>
+    """
+
+@app.get("/api")
+async def api_root():
+    return {"message": "Hello from backend API"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/backoffice/Dockerfile
+++ b/backoffice/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "11002"]

--- a/backoffice/main.py
+++ b/backoffice/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+@app.get("/", response_class=HTMLResponse)
+async def login_page(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request, "error": None, "success": False})
+
+@app.post("/login", response_class=HTMLResponse)
+async def login(request: Request, username: str = Form(...), password: str = Form(...)):
+    if username == "admin" and password == "password":
+        return templates.TemplateResponse("index.html", {"request": request, "success": True, "error": None})
+    return templates.TemplateResponse("index.html", {"request": request, "error": "Invalid credentials", "success": False})

--- a/backoffice/requirements.txt
+++ b/backoffice/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+jinja2

--- a/backoffice/templates/index.html
+++ b/backoffice/templates/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Backoffice</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container py-5">
+  <h1>Backoffice Login</h1>
+  {% if error %}
+  <div class="alert alert-danger">{{ error }}</div>
+  {% endif %}
+  {% if success %}
+  <div class="alert alert-success">Logged in!</div>
+  {% else %}
+  <form method="post" action="/login">
+    <div class="mb-3">
+      <label for="username" class="form-label">Username</label>
+      <input id="username" name="username" class="form-control" />
+    </div>
+    <div class="mb-3">
+      <label for="password" class="form-label">Password</label>
+      <input id="password" name="password" type="password" class="form-control" />
+    </div>
+    <button class="btn btn-primary" type="submit">Login</button>
+  </form>
+  {% endif %}
+</body>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "15001:11001"
+  backoffice:
+    build: ./backoffice
+    ports:
+      - "15002:11002"
+    depends_on:
+      - backend
+  yb100:
+    build: ./yb100
+    ports:
+      - "15000:80"
+    depends_on:
+      - backend
+  ms:
+    build: ./ms
+    ports:
+      - "16000:80"
+    depends_on:
+      - backend
+  fs:
+    build: ./fs
+    ports:
+      - "17000:80"
+    depends_on:
+      - backend
+  xmas:
+    build: ./xmas
+    ports:
+      - "18000:80"
+    depends_on:
+      - backend

--- a/fs/Dockerfile
+++ b/fs/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY public /usr/share/nginx/html

--- a/fs/public/app.js
+++ b/fs/public/app.js
@@ -1,0 +1,14 @@
+function App() {
+  const [message, setMessage] = React.useState("");
+
+  React.useEffect(() => {
+    fetch("http://localhost:15001/api")
+      .then(res => res.json())
+      .then(data => setMessage(data.message))
+      .catch(() => setMessage("API unavailable"));
+  }, []);
+
+  return React.createElement('div', null, message || 'Loading...');
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/fs/public/index.html
+++ b/fs/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>FS</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/ms/Dockerfile
+++ b/ms/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY public /usr/share/nginx/html

--- a/ms/public/app.js
+++ b/ms/public/app.js
@@ -1,0 +1,14 @@
+function App() {
+  const [message, setMessage] = React.useState("");
+
+  React.useEffect(() => {
+    fetch("http://localhost:15001/api")
+      .then(res => res.json())
+      .then(data => setMessage(data.message))
+      .catch(() => setMessage("API unavailable"));
+  }, []);
+
+  return React.createElement('div', null, message || 'Loading...');
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/ms/public/index.html
+++ b/ms/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>MS</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+sudo docker-compose down --volumes --remove-orphans
+sudo docker-compose build --no-cache
+sudo docker-compose up -d
+
+echo "- **Backend API:** http://localhost:15001"
+echo "- **Backoffice:** http://localhost:15002"
+echo "- **Frontends:**"
+echo "  - http://localhost:15000 (yb100)"
+echo "  - http://localhost:16000 (ms)"
+echo "  - http://localhost:17000 (fs)"
+echo "  - http://localhost:18000 (xmas)"

--- a/xmas/Dockerfile
+++ b/xmas/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY public /usr/share/nginx/html

--- a/xmas/public/app.js
+++ b/xmas/public/app.js
@@ -1,0 +1,14 @@
+function App() {
+  const [message, setMessage] = React.useState("");
+
+  React.useEffect(() => {
+    fetch("http://localhost:15001/api")
+      .then(res => res.json())
+      .then(data => setMessage(data.message))
+      .catch(() => setMessage("API unavailable"));
+  }, []);
+
+  return React.createElement('div', null, message || 'Loading...');
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/xmas/public/index.html
+++ b/xmas/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Xmas</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/yb100/Dockerfile
+++ b/yb100/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY public /usr/share/nginx/html

--- a/yb100/public/app.js
+++ b/yb100/public/app.js
@@ -1,0 +1,14 @@
+function App() {
+  const [message, setMessage] = React.useState("");
+
+  React.useEffect(() => {
+    fetch("http://localhost:15001/api")
+      .then(res => res.json())
+      .then(data => setMessage(data.message))
+      .catch(() => setMessage("API unavailable"));
+  }, []);
+
+  return React.createElement('div', null, message || 'Loading...');
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/yb100/public/index.html
+++ b/yb100/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>YB100</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@7/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI backend with Bootstrap landing page and API endpoint
- add backoffice FastAPI app with Bootstrap login template
- scaffold React frontends (yb100, ms, fs, xmas) served via nginx
- configure docker-compose and start script to orchestrate services

## Testing
- `python -m py_compile backend/main.py backoffice/main.py`
- `bash -n start.sh`
- ⚠️ `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b302251b0c8325951f1a477e2d5710