### PR TITLE
Fix backend status and add MongoDB test endpoint; build frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: ./backend
     ports:
       - "15001:11001"
+    env_file:
+      - .env
   backoffice:
     build: ./backoffice
     ports:

--- a/yb100/Dockerfile
+++ b/yb100/Dockerfile
@@ -1,7 +1,13 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
 FROM node:18-alpine
 WORKDIR /app
-COPY public ./public
 RUN npm install -g serve
+COPY --from=build /app/dist ./dist
 EXPOSE 80
-CMD ["serve", "-s", "public", "-l", "80"]
-
+CMD ["serve", "-s", "dist", "-l", "80"]


### PR DESCRIPTION
## Summary
- make backend status page resilient to missing collections
- add `/mongo-test` endpoint that pings MongoDB and ensures default collections
- build yb100 app in Docker image and serve compiled `dist`
- load backend environment variables from `.env`

## Testing
- `python -m py_compile main.py`
- `pytest`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b55e4539f08325ad8aebbcccda9646