### PR TITLE
Add missing cn utility to frontend apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/fs/src/lib/utils.ts
+++ b/fs/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+

--- a/sp/src/lib/utils.ts
+++ b/sp/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+

--- a/xmas/src/lib/utils.ts
+++ b/xmas/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+

--- a/yb100/src/lib/utils.ts
+++ b/yb100/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+


### PR DESCRIPTION
## Summary
- add `cn` helper under `src/lib` for each frontend package
- adjust `.gitignore` to allow committing `lib` directories

## Testing
- `cd xmas && npm run build`
- `cd sp && npm run build`
- `cd fs && npm run build`
- `cd yb100 && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5894f61f08325a6818a386237dd9a