### PR TITLE
Update favicons and backend landing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Once running, the following endpoints are available:
   - `/list` – GET latest list or fetch by `id`/`keyword`, POST to create, PUT to update.
   - `/items` – GET recent items or fetch by `id`, POST to create, PUT to update.
   - `/images` – GET 100 random image URLs.
-  - `/docs` – Swagger API documentation.
+- **Swagger Docs:** http://localhost:15001/docs
 - **Backoffice:** http://localhost:15002
 - **Frontends:**
   - http://localhost:15000 (yb100)

--- a/backend/main.py
+++ b/backend/main.py
@@ -56,32 +56,47 @@ async def root() -> str:
         except Exception:
             item_count = 0
     return f"""
-    <!doctype html>
-    <html lang='en'>
-    <head>
-      <meta charset='utf-8'>
-      <title>Backend API</title>
-      <link href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css' rel='stylesheet'>
-    </head>
-    <body class='container py-5'>
-      <h1>Backend API</h1>
-      <p>Status: {status}</p>
-      <p>Database: {DB_NAME}</p>
-      <p>Collections:</p>
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='utf-8'>
+  <title>Backend API</title>
+  <link href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css' rel='stylesheet'>
+</head>
+<body class='container py-5'>
+  <h1>Backend API</h1>
+  <h2>Status</h2>
+  <ul>
+    <li>Status: {status}</li>
+    <li>Database: {DB_NAME}</li>
+    <li>{LISTS_COLLECTION} ({list_count} docs)</li>
+    <li>{ITEMS_COLLECTION} ({item_count} docs)</li>
+  </ul>
+  <h2>Endpoints</h2>
+  <ul>
+    <li><a href='/list'>/list</a> - GET latest list, POST add list, PUT update list</li>
+    <li><a href='/items'>/items</a> - GET latest items, POST add item, PUT update item</li>
+    <li><a href='/images'>/images</a> - GET 100 random images</li>
+    <li><a href='/docs'>Swagger documentation</a></li>
+  </ul>
+  <h2>Links</h2>
+  <ul>
+    <li><a href='http://localhost:15000'>Frontend</a></li>
+    <li><a href='http://localhost:15001'>Backend</a></li>
+    <li><a href='/docs'>Docs</a></li>
+    <li>Frontend Sites
       <ul>
-        <li>{LISTS_COLLECTION} ({list_count} docs)</li>
-        <li>{ITEMS_COLLECTION} ({item_count} docs)</li>
+        <li><a href='http://localhost:15000'>yb100</a></li>
+        <li><a href='http://localhost:16000'>fs</a></li>
+        <li><a href='http://localhost:17000'>sp</a></li>
+        <li><a href='http://localhost:18000'>xmas</a></li>
       </ul>
-      <h2>Endpoints</h2>
-      <ul>
-        <li><a href='/list'>/list</a> - GET latest list, POST add list, PUT update list</li>
-        <li><a href='/items'>/items</a> - GET latest items, POST add item, PUT update item</li>
-        <li><a href='/images'>/images</a> - GET 100 random images</li>
-        <li><a href='/docs'>Swagger documentation</a></li>
-      </ul>
-    </body>
-    </html>
-    """
+    </li>
+    <li><a href='../README.md'>Readme</a></li>
+  </ul>
+</body>
+</html>
+"""
 
 
 @app.get("/mongo-test")

--- a/fs/index.html
+++ b/fs/index.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48Y2lyY2xlIGN4PSc1MCcgY3k9JzUwJyByPSc1MCcgZmlsbD0nYmx1ZScvPjwvc3ZnPg==">
   </head>
 
   <body>

--- a/sp/index.html
+++ b/sp/index.html
@@ -19,6 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48Y2lyY2xlIGN4PSc1MCcgY3k9JzUwJyByPSc1MCcgZmlsbD0nYmx1ZScvPjwvc3ZnPg==">
   </head>
 
   <body>

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,7 @@ docker compose build --no-cache
 docker compose up -d
 
 echo "- **Backend API:** http://localhost:15001"
+echo "- **Swagger Docs:** http://localhost:15001/docs"
 echo "- **Backoffice:** http://localhost:15002"
 echo "- **Frontends:**"
 echo "  - http://localhost:15000 (yb100)"

--- a/xmas/index.html
+++ b/xmas/index.html
@@ -15,6 +15,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48Y2lyY2xlIGN4PSc1MCcgY3k9JzUwJyByPSc1MCcgZmlsbD0nYmx1ZScvPjwvc3ZnPg==">
   </head>
 
   <body>

--- a/yb100/index.html
+++ b/yb100/index.html
@@ -16,6 +16,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@yourbest100" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAxMDAgMTAwJz48Y2lyY2xlIGN4PSc1MCcgY3k9JzUwJyByPSc1MCcgZmlsbD0nYmx1ZScvPjwvc3ZnPg==">
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- Embed blue-circle SVG favicons directly in each frontend HTML
- Print Swagger Docs URL in `start.sh`
- Expand backend root page with Status, Endpoints, and Links sections
- Mention Swagger docs in README

## Testing
- `pytest`
- `cd fs && npm test` *(fails: Missing script "test")*
- `cd sp && npm test` *(fails: Missing script "test")*
- `cd xmas && npm test` *(fails: Missing script "test")*
- `cd yb100 && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5757373e88325a5ee1a76af70f3a6