### PR TITLE
feat: async backend index status page

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pymongo
 python-dotenv
 requests
+httpx


### PR DESCRIPTION
## Summary
- add Bootstrap 5.3 index with sticky header/footer and overview sections
- async checks for API, external site, MongoDB, and optional LLM
- include httpx dependency for async HTTP requests

## Testing
- `python -m py_compile backend/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6883d3074832589411a63303d1be5