### PR TITLE
Add service index with status sections

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,4 @@
+# Backlog
+
+- Improve API documentation
+- Add more unit tests


### PR DESCRIPTION
## Summary
- extend backend root to include service and dependency checks
- add sticky bootstrap layout with sections for status, links, endpoints, readme and backlog
- add project backlog placeholder

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6917028b48325af8cf65e2dde8628