### PR TITLE
Ensure backoffice falls back to default admin credentials

### DIFF
--- a/backoffice/main.py
+++ b/backoffice/main.py
@@ -13,8 +13,9 @@ from pymongo import MongoClient
 
 load_dotenv()
 
-ADMIN_USERNAME = os.getenv("ADMIN_USERNAME", "admin")
-ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "changeme")
+# fall back to defaults if the environment variables are unset or blank
+ADMIN_USERNAME = (os.getenv("ADMIN_USERNAME") or "admin").strip()
+ADMIN_PASSWORD = (os.getenv("ADMIN_PASSWORD") or "changeme").strip()
 MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 MONGODB_DB = os.getenv("MONGODB_DB", "AIDB")
 MONGODB_COLLECTION = os.getenv("MONGODB_COLLECTION", "ITEMS")


### PR DESCRIPTION
## Summary
- Avoid empty `ADMIN_USERNAME`/`ADMIN_PASSWORD` by defaulting to `admin`/`changeme` when env vars are unset or blank

## Testing
- `python -m py_compile backoffice/main.py && echo 'py_compile success'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b69cea8bfc8325959fe7d64eecd7e0