### PR TITLE
Handle missing admin credentials in backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,8 +21,6 @@ MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 DB_NAME = os.getenv("MONGODB_DB", "AIDB")
 LISTS_COLLECTION = os.getenv("LISTS_COLLECTION", "DAILY")
 ITEMS_COLLECTION = os.getenv("ITEMS_COLLECTION", "ITEMS")
-ADMIN_USERNAME = os.getenv("ADMIN_USERNAME", "")
-ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "")
 BASE_DIR = Path(__file__).resolve().parents[1]
 security = HTTPBasic()
 
@@ -36,8 +34,12 @@ app = FastAPI(title="Backend API")
 
 def verify(credentials: HTTPBasicCredentials = Depends(security)) -> str:
     """Validate basic auth credentials."""
-    correct_username = secrets.compare_digest(credentials.username, ADMIN_USERNAME)
-    correct_password = secrets.compare_digest(credentials.password, ADMIN_PASSWORD)
+    username = os.getenv("ADMIN_USERNAME")
+    password = os.getenv("ADMIN_PASSWORD")
+    if not username or not password:
+        raise HTTPException(status_code=500, detail="ADMIN credentials not set")
+    correct_username = secrets.compare_digest(credentials.username, username)
+    correct_password = secrets.compare_digest(credentials.password, password)
     if not (correct_username and correct_password):
         raise HTTPException(
             status_code=401,

--- a/backend/test_auth.py
+++ b/backend/test_auth.py
@@ -1,0 +1,30 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPBasicCredentials
+
+import main
+
+
+def test_verify_success(monkeypatch):
+    monkeypatch.setenv("ADMIN_USERNAME", "user")
+    monkeypatch.setenv("ADMIN_PASSWORD", "pass")
+    creds = HTTPBasicCredentials(username="user", password="pass")
+    assert main.verify(creds) == "user"
+
+
+def test_verify_missing_env(monkeypatch):
+    monkeypatch.delenv("ADMIN_USERNAME", raising=False)
+    monkeypatch.delenv("ADMIN_PASSWORD", raising=False)
+    creds = HTTPBasicCredentials(username="x", password="y")
+    with pytest.raises(HTTPException) as exc:
+        main.verify(creds)
+    assert exc.value.status_code == 500
+
+
+def test_verify_wrong_credentials(monkeypatch):
+    monkeypatch.setenv("ADMIN_USERNAME", "user")
+    monkeypatch.setenv("ADMIN_PASSWORD", "pass")
+    creds = HTTPBasicCredentials(username="user", password="wrong")
+    with pytest.raises(HTTPException) as exc:
+        main.verify(creds)
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary
- use `ADMIN_USERNAME`/`ADMIN_PASSWORD` env vars for backend HTTP Basic auth
- return error when admin credentials not configured
- add tests for login behaviour

## Testing
- `python -m py_compile backend/main.py backend/test_auth.py`
- `pytest backend/test_auth.py` *(fails: ModuleNotFoundError: No module named 'markdown')*

------
https://chatgpt.com/codex/tasks/task_e_68b709d02ca483258cdbd3da00d25c21