### PR TITLE
Add sticky footer, dark theme default, and random list scroller

### DIFF
--- a/yb100/src/App.tsx
+++ b/yb100/src/App.tsx
@@ -10,6 +10,9 @@ import Auth from "./pages/Auth";
 import Admin from "./pages/Admin";
 import CreateList from "./pages/CreateList";
 import NotFound from "./pages/NotFound";
+import About from "./pages/About";
+import Scroller from "./pages/Scroller";
+import StickyFooter from "@/components/Layout/StickyFooter";
 
 const queryClient = new QueryClient();
 
@@ -25,8 +28,11 @@ const App = () => (
           <Route path="/auth" element={<Auth />} />
           <Route path="/admin" element={<Admin />} />
           <Route path="/create" element={<CreateList />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/scroller" element={<Scroller />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
+        <StickyFooter />
       </BrowserRouter>
     </TooltipProvider>
   </QueryClientProvider>

--- a/yb100/src/components/Layout/StickyFooter.tsx
+++ b/yb100/src/components/Layout/StickyFooter.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+
+const StickyFooter = () => {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 bg-background/90 backdrop-blur border-t border-gray-200 dark:border-gray-700">
+      <div className="max-w-7xl mx-auto px-4 py-2 flex justify-center space-x-4">
+        <Button variant="ghost" asChild>
+          <Link to="/about">About</Link>
+        </Button>
+        <Button variant="ghost" asChild>
+          <Link to="/scroller">Scroller</Link>
+        </Button>
+        <Button variant="ghost" asChild>
+          <Link to="/">Tiles</Link>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default StickyFooter;

--- a/yb100/src/index.css
+++ b/yb100/src/index.css
@@ -38,6 +38,11 @@
     --ring: 222.2 84% 4.9%;
     --radius: 0.75rem;
   }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+  }
 }
 
 @layer base {

--- a/yb100/src/main.tsx
+++ b/yb100/src/main.tsx
@@ -4,7 +4,7 @@ import './index.css'
 import { ThemeProvider } from "@/components/theme-provider";
 
 createRoot(document.getElementById("root")!).render(
-  <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+  <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
     <App />
   </ThemeProvider>
 );

--- a/yb100/src/pages/About.tsx
+++ b/yb100/src/pages/About.tsx
@@ -1,0 +1,22 @@
+import Header from '@/components/Layout/Header';
+import Footer from '@/components/Layout/Footer';
+
+const About = () => {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Header />
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h1 className="text-3xl font-bold mb-4">About YourBest100</h1>
+        <p className="text-neutral-muted mb-4">
+          YourBest100 is a community-driven platform for discovering and sharing top-100 lists on any topic. Explore curated lists, vote on your favorites and create your own rankings.
+        </p>
+        <p className="text-neutral-muted">
+          This project is built with modern web technologies and aims to provide a fun, engaging experience for list lovers everywhere.
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default About;

--- a/yb100/src/pages/Index.tsx
+++ b/yb100/src/pages/Index.tsx
@@ -45,7 +45,7 @@ const Index = () => {
   const regularLists = filteredLists.filter(list => !list.featured);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background text-foreground">
       <Header onSearch={handleSearch} />
       
       {/* Hero Section */}

--- a/yb100/src/pages/ListDetail.tsx
+++ b/yb100/src/pages/ListDetail.tsx
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, Share2, Heart, TrendingUp, Calendar, User } from 'lucide-react';
 import Header from '@/components/Layout/Header';
 import Footer from '@/components/Layout/Footer';
@@ -11,6 +11,7 @@ import { useToast } from '@/hooks/use-toast';
 
 const ListDetail = () => {
   const { slug } = useParams<{ slug: string }>();
+  const [searchParams] = useSearchParams();
   const [list, setList] = useState<TopList | null>(null);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
@@ -23,6 +24,17 @@ const ListDetail = () => {
       setLoading(false);
     }, 500);
   }, [slug]);
+
+  useEffect(() => {
+    if (!list) return;
+    const itemId = searchParams.get('item');
+    if (itemId) {
+      const el = document.getElementById(itemId);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }
+  }, [list, searchParams]);
 
   const handleVote = (itemId: string) => {
     if (!list) return;
@@ -61,7 +73,7 @@ const ListDetail = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-white">
+      <div className="min-h-screen bg-background text-foreground">
         <Header />
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           <div className="animate-pulse">
@@ -81,7 +93,7 @@ const ListDetail = () => {
 
   if (!list) {
     return (
-      <div className="min-h-screen bg-white">
+      <div className="min-h-screen bg-background text-foreground">
         <Header />
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
           <h1 className="text-4xl font-bold text-gray-900 mb-4">List Not Found</h1>
@@ -96,7 +108,7 @@ const ListDetail = () => {
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-background text-foreground">
       <Header />
       
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -187,7 +199,7 @@ const ListDetail = () => {
 
 const ListItemCard = ({ item, onVote }: { item: ListItem; onVote: () => void }) => {
   return (
-    <div className="bg-white rounded-xl card-shadow p-6 hover:shadow-md transition-shadow duration-200">
+    <div id={item.id} className="bg-white rounded-xl card-shadow p-6 hover:shadow-md transition-shadow duration-200">
       <div className="flex items-start space-x-4">
         {/* Rank */}
         <div className="flex-shrink-0">

--- a/yb100/src/pages/Scroller.tsx
+++ b/yb100/src/pages/Scroller.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import Header from '@/components/Layout/Header';
+import Footer from '@/components/Layout/Footer';
+import { sampleLists } from '@/data/sampleData';
+
+const Scroller = () => {
+  const itemRefs = useRef<HTMLDivElement[]>([]);
+
+  useEffect(() => {
+    const randomIndex = Math.floor(Math.random() * sampleLists.length);
+    const el = itemRefs.current[randomIndex];
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, []);
+
+  const getRandomItemLink = (slug: string) => {
+    const list = sampleLists.find(l => l.slug === slug);
+    if (!list || list.items.length === 0) return `/lists/${slug}`;
+    const randomItem = list.items[Math.floor(Math.random() * list.items.length)];
+    return `/lists/${slug}?item=${randomItem.id}`;
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Header />
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-4">
+        {sampleLists.map((list, index) => (
+          <div
+            key={list.id}
+            ref={el => {
+              if (el) itemRefs.current[index] = el;
+            }}
+            className="bg-white dark:bg-gray-800 rounded-xl card-shadow p-4 hover:shadow-md transition-shadow"
+          >
+            <Link to={getRandomItemLink(list.slug)} className="text-xl font-semibold">
+              {list.title}
+            </Link>
+          </div>
+        ))}
+      </div>
+      <Footer />
+    </div>
+  );
+};
+
+export default Scroller;


### PR DESCRIPTION
## Summary
- default to dark theme and add basic dark variables
- introduce sticky footer with links to About, Scroller, and Tiles views
- add About page, random list Scroller view, and ListDetail support for direct item links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint: not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b70caddda083258de31b906e5b7703